### PR TITLE
Create puttykey.gemspec and dont fail on Windows newlines

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Hoe.plugin :minitest
 
 spec = Hoe.spec 'puttykey' do
   developer "Lars Christensen", "larsch@belunktum.dk"
-  license "MIt"
+  license "MIT"
 end
 
 desc "Test packaged gem"

--- a/lib/puttykey.rb
+++ b/lib/puttykey.rb
@@ -163,6 +163,8 @@ class PuttyKey
   end
 
   def parse(string, passphrase = nil)
+    # Ensure we only have unix line breaks
+    string.encode!(universal_newline: true)
     lns = string.lines.to_a
     until lns.empty?
       if lns.shift =~ /(\S+): (.*)/

--- a/puttykey.gemspec
+++ b/puttykey.gemspec
@@ -1,0 +1,15 @@
+Gem::Specification.new do |s|
+  s.name        = 'puttykey'
+  s.version     = '0.0.1'
+  s.date        = '2015-05-18'
+  s.summary     = "PuTTY Key Parser/Formatter"
+  s.description = "Parse, format PuTTY private keys (.ppk) format. Convert PuTTY keys to SSL keys."
+  s.authors     = ["Lars Christensen"]
+  s.email       = 'larsch@belunktum.dk'
+  s.files       = ["lib/puttykey.rb"]
+  s.extra_rdoc_files = ["README.rdoc"]
+  s.platform    = "ruby"
+  s.homepage    =
+    'https://github.com/larsch/puttykey'
+  s.license       = 'MIT'
+end

--- a/puttykey.gemspec
+++ b/puttykey.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'puttykey'
-  s.version     = '0.0.1'
+  s.version     = '0.0.2'
   s.date        = '2015-05-18'
   s.summary     = "PuTTY Key Parser/Formatter"
   s.description = "Parse, format PuTTY private keys (.ppk) format. Convert PuTTY keys to SSL keys."

--- a/test/test_puttykey.rb
+++ b/test/test_puttykey.rb
@@ -27,6 +27,10 @@ class TestPuttykey < Minitest::Test
     assert_reference PuttyKey.parse(PPK_CLEAR)
   end
 
+  def test_parse_windows_linebreaks
+    assert_reference PuttyKey.parse(PPK_WINDOWS)
+  end
+
   def test_parse_decrypt
     assert_reference PuttyKey.parse(PPK_ENCRYPTED, PPK_PASSPHRASE)
   end
@@ -143,3 +147,5 @@ Private-MAC: 865dc67d9192307d80aa6847ac7aa53475562e2d
 "
 
 PPK_PASSPHRASE = "asdf"
+
+PPK_WINDOWS = PPK_CLEAR.gsub("\n","\r\n")


### PR DESCRIPTION
There was no gemspec file

The parse function would fail if the line endings were Windows style `\r\n`

Couple of other tidies. 
